### PR TITLE
Remove deprecated BigDecimal.new usage.

### DIFF
--- a/lib/tax_cloud/responses/cart_item.rb
+++ b/lib/tax_cloud/responses/cart_item.rb
@@ -16,7 +16,7 @@ module TaxCloud #:nodoc:
       # [savon_response] SOAP response.
       def initialize(savon_response)
         self.cart_item_index = savon_response[:cart_item_index].to_i
-        self.tax_amount = BigDecimal.new(savon_response[:tax_amount])
+        self.tax_amount = BigDecimal(savon_response[:tax_amount])
       end
     end
   end


### PR DESCRIPTION
Use the supported BigDecimal(.) form

Necessary to support Ruby 2.7+

Reference: https://docs.ruby-lang.org/en/2.6.0/NEWS.html#label-Stdlib+updates+-28outstanding+ones+only-29
Also, see upstream fix: https://github.com/txcrb/tax_cloud/pull/41, which we are never receiving because we aren't tracking the upstream project since this branch has many changes which are never being pulled upstream.


Related to [Upgrade to Ruby 2.7](https://app.asana.com/0/1201324750427113/1203482278097875/f)